### PR TITLE
feat: add standard github ci features

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS should allow you to have PR's auto marked for your review.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+#
+* @quotidian-ennui

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 20
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "deps(actions): "

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,76 @@
+name: Check PR
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          reporter: github-pr-review
+          pattern: gh-squash-merge
+          fail_on_error: true
+          github_token: ${{ secrets.github_token }}
+
+  committed:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    if: |
+      github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: committed
+        uses: crate-ci/committed@v1.0.20
+        with:
+          args: --no-merge-commit
+
+  typos:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: typos
+        uses: crate-ci/typos@v1.16.14
+
+  dependabot-merge:
+    needs:
+      - shellcheck
+      - committed
+      - typos
+    permissions:
+      contents: write
+      pull-requests: write
+    if: |
+      github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Find associated PR
+      uses: jwalton/gh-find-current-pr@v1.3.2
+      id: findpr
+      with:
+        github-token: ${{ github.token }}
+        state: open
+        sha: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+    - name: merge-if-built
+      continue-on-error: true
+      uses: fastify/github-action-merge-dependabot@v3.9.1
+      with:
+        pr-number: ${{ steps.findpr.outputs.pr }}
+        target: minor

--- a/README.md
+++ b/README.md
@@ -1,2 +1,61 @@
 # gh-squash-merge
 Squash+Merge a PR with a commit based on the PR body
+# gh-my
+
+We use squash merge a lot when messing around with pull requests. One of the things that has irked me is the _manual love_ that we need to sometimes apply when doing the commit message on merge. If you do not have structured commit messages and it's multiple commits you want to squash merge, then you effectively have to stop and think at the point of merge.
+
+You actually need to have some kind of discipline in place in order to seamlessly 'just use an aggregation of all your commit messages on that PR branch'; I'm all for discipline, but this is a case
+
+This is an extension for [GitHub CLI](https://cli.github.com/) that just parses your PR body for some meaningful text and uses that as the commit message when you squash merge.
+
+
+## Installation
+
+- [GitHub CLI](https://cli.github.com/) is already installed and authenticated
+- awk is available, untested with awk on MacOS; but I don't think I'm doing anything _special_ in awk...
+- Just `gh extension install quotidian-ennui/gh-squash-merge`
+
+## Setup
+
+You probably want to have a `pull_request_template.md` available in your repo / organisation that looks something like this; it should be self-explanatory why the boundary markers are there.
+
+```
+# Motivation
+<!-- Why am I doing this -->
+
+## Changes
+
+<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
+     approved and merged -->
+<!-- SQUASH_MERGE_START -->
+
+<!-- SQUASH_MERGE_END -->
+```
+
+- Any text that you write between the `SQUASH_MERGE_START` & `SQUASH_MERGE_END` will be used as the commit message.
+
+### Usage
+
+```
+Usage: gh squash-merge <pr-number>
+
+Issues a squash merge on the PR number provided.
+
+- The title of the commit is the title of the PR
+- The PR body contains a section similar to the following which lets us autogenerate
+  squash merge commit message
+
+<!-- SQUASH_MERGE_START -->
+- this forms the body of the commit message and could be multiple lines
+but generally we tend towards
+- doc: conventional commit messages
+<!-- SQUASH_MERGE_END -->
+
+EXAMPLES
+gh squash-merge 811
+```
+
+
+## License
+
+See [LICENSE](./LICENSE)

--- a/committed.toml
+++ b/committed.toml
@@ -1,0 +1,5 @@
+style="conventional"
+allowed_types=["fix", "feat", "chore", "docs", "doc", "style", "refactor", "perf", "test", "build", "deps", "ci"]
+ignore_author_re="(dependabot|renovate)"
+subject_capitalized=false
+subject_not_punctuated=false

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,11 @@
+# Motivation
+<!-- Why am I doing this -->
+
+## Changes
+
+<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
+     approved and merged -->
+<!-- SQUASH_MERGE_START -->
+
+<!-- SQUASH_MERGE_END -->
+


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Must have dependabot + github actions; and also let's test the script! When this PR is merged using gh-squash-merge we should see that the commit message associated with the merge has no relationship to the actual commit messages in the branch and should be taken from the PR body.

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- add README for minimal documentation
- add simple CODEOWNER file
- add dependabot and github actions on PR.
<!-- SQUASH_MERGE_END -->