### PR TITLE
feat: remove title override from pr merge

### DIFF
--- a/gh-squash-merge
+++ b/gh-squash-merge
@@ -90,11 +90,10 @@ if [ -n "${remaining_args:-}" ]; then
   details_args+=("${remaining_args}")
 fi
 
-pr_details=$(gh pr view --json title,body $"${details_args[@]}")
+pr_details=$(gh pr view --json body $"${details_args[@]}")
 
-title=$(jq -r .title <<<"$pr_details")
 body=$(jq -r .body <<<"$pr_details")
 
 echo "$body" | awk '/SQUASH_MERGE_START/,/SQUASH_MERGE_END/' | grep -v "SQUASH_MERGE" >"$WORK_FILE"
-gh pr merge $"${details_args[@]}" --delete-branch --squash --body-file "$WORK_FILE" --subject "$title"
+gh pr merge $"${details_args[@]}" --delete-branch --squash --body-file "$WORK_FILE"
 cleanup


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Removing the title lets GitHub do the work, which for squash-merging adds the PR number in brackets:

```text
* 0480f0c - (8 minutes ago) docs: update usage docs for #10 (#11)
* f76c9b5 - (22 minutes ago) feat: add support for pr cli contract
```

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- Remove title from pr view query
- Remove parsing that on to pr merge
<!-- SQUASH_MERGE_END -->

