### PR TITLE
feat: allow for empty bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This is an extension for [GitHub CLI](https://cli.github.com/) that just parses 
 ## Installation
 
 - [GitHub CLI](https://cli.github.com/) is already installed and authenticated
-- `jq` is available
 - `awk` is available, untested with awk on MacOS; but I don't think I'm doing anything _special_ in `awk`...
 - `mktemp` is available, untested with `mktemp` on MacOS; but `--tmpdir` isn't that special right?
 - `gh extension install quotidian-ennui/gh-squash-merge`

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ This is an extension for [GitHub CLI](https://cli.github.com/) that just parses 
 ## Installation
 
 - [GitHub CLI](https://cli.github.com/) is already installed and authenticated
-- awk is available, untested with awk on MacOS; but I don't think I'm doing anything _special_ in awk...
-- mktemp is available, untested with mktemp on MacOS; but `--tmpdir` isn't that special right?
+- `jq` is available
+- `awk` is available, untested with awk on MacOS; but I don't think I'm doing anything _special_ in `awk`...
+- `mktemp` is available, untested with `mktemp` on MacOS; but `--tmpdir` isn't that special right?
 - `gh extension install quotidian-ennui/gh-squash-merge`
 
 ## Setup
@@ -51,9 +52,10 @@ Flags
   -R, --repo [HOST/]OWNER/REPO   Select another repository using the [HOST/]OWNER/REPO format
 
 Notes:
-- The title of the commit is the title of the PR
+- The title of the commit will be based on GitHub repository settings
 - The PR body contains a section similar to the following which lets us autogenerate
   squash merge commit message
+- If PR body does not contain a section similar an empty body will be set
 
 <!-- SQUASH_MERGE_START -->
 - this forms the body of the commit message and could be multiple lines

--- a/gh-squash-merge
+++ b/gh-squash-merge
@@ -91,9 +91,7 @@ if [ -n "${remaining_args:-}" ]; then
   details_args+=("${remaining_args}")
 fi
 
-pr_details=$(gh pr view --json body $"${details_args[@]}")
-
-body=$(jq -r .body <<<"$pr_details")
+body=$(gh pr view --json body $"${details_args[@]}" --jq '.body')
 
 echo "$body" | awk '/SQUASH_MERGE_START/,/SQUASH_MERGE_END/' | { grep -v "SQUASH_MERGE" || test $? = 1; } >"$WORK_FILE"
 gh pr merge $"${details_args[@]}" --delete-branch --squash --body-file "$WORK_FILE"

--- a/gh-squash-merge
+++ b/gh-squash-merge
@@ -28,9 +28,10 @@ Flags
   -R, --repo [HOST/]OWNER/REPO   Select another repository using the [HOST/]OWNER/REPO format
 
 Notes:
-- The title of the commit is the title of the PR
+- The title of the commit will be based on GitHub repository settings
 - The PR body contains a section similar to the following which lets us autogenerate
   squash merge commit message
+- If PR body does not contain a section similar an empty body will be set
 
 <!-- SQUASH_MERGE_START -->
 - this forms the body of the commit message and could be multiple lines
@@ -94,6 +95,6 @@ pr_details=$(gh pr view --json body $"${details_args[@]}")
 
 body=$(jq -r .body <<<"$pr_details")
 
-echo "$body" | awk '/SQUASH_MERGE_START/,/SQUASH_MERGE_END/' | grep -v "SQUASH_MERGE" >"$WORK_FILE"
+echo "$body" | awk '/SQUASH_MERGE_START/,/SQUASH_MERGE_END/' | { grep -v "SQUASH_MERGE" || test $? = 1; } >"$WORK_FILE"
 gh pr merge $"${details_args[@]}" --delete-branch --squash --body-file "$WORK_FILE"
 cleanup


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

I wanted to use it for a `updatecli` PR that had made multiple commits, the squash and merge body via GitHub included all the commits. Instead of editing the PR I thought this could work and set an empty body as there was no match.

What I found was the `grep` was causing the `gh squash-merge` to silently do nothing.

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- add test for grep exit code: 1 means no match, 2 is a failure.
- refactor: remove the need for jq as there's no longer multiple queries on pr view.
<!-- SQUASH_MERGE_END -->

