### PR TITLE
feat: add --dry-run to print the commit msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ Arguments
   <branch> The branch of PR URL to squash merge
 
 Flags
+      --admin                    Use administrator privileges to merge a pull request that does not meet requirement
+      --auto                     Automatically merge only after necessary requirements are met
   -R, --repo [HOST/]OWNER/REPO   Select another repository using the [HOST/]OWNER/REPO format
+      --dry-run                  dry run; in effect print the message that would be used for the squash commit
 
 Notes:
 - The title of the commit will be based on GitHub repository settings

--- a/gh-squash-merge
+++ b/gh-squash-merge
@@ -28,6 +28,7 @@ Flags
       --admin                    Use administrator privileges to merge a pull request that does not meet requirement
       --auto                     Automatically merge only after necessary requirements are met
   -R, --repo [HOST/]OWNER/REPO   Select another repository using the [HOST/]OWNER/REPO format
+      --dry-run                  dry run; in effect print the message that would be used for the squash commit
 
 Notes:
 - The title of the commit will be based on GitHub repository settings
@@ -56,10 +57,15 @@ trap cleanup 1 2 15
 
 additional_args=()
 
-ARGS=$(getopt --options 'R::h' --longoptions 'repo:,help,admin,auto' -- "${@}")
+DRY_RUN=false
+ARGS=$(getopt --options 'R::h' --longoptions 'repo:,help,admin,auto,dry-run' -- "${@}")
 eval "set -- ${ARGS}"
 while true; do
   case "${1}" in
+  --dry-run)
+    DRY_RUN=true
+    shift
+    ;;
   --h | --help)
     usage
     ;;
@@ -102,5 +108,11 @@ fi
 body=$(gh pr view --json body $"${details_args[@]}" --jq '.body')
 
 echo "$body" | awk '/SQUASH_MERGE_START/,/SQUASH_MERGE_END/' | { grep -v "SQUASH_MERGE" || test $? = 1; } >"$WORK_FILE"
-gh pr merge $"${details_args[@]}" --delete-branch --squash --body-file "$WORK_FILE" $"${additional_args[@]}"
+if [[ "$DRY_RUN" == "true" ]]; then
+  title=$(gh pr view --json title $"${details_args[@]}" --jq '.title')
+  echo -e "$title\n"
+  cat "$WORK_FILE"
+else
+  gh pr merge $"${details_args[@]}" --delete-branch --squash --body-file "$WORK_FILE" $"${additional_args[@]}"
+fi
 cleanup


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Because we put it into `bb-pr squash-msg`; add dry-run capability to print out the commit message we would have used

Is `--dry-run` too long, should there also be a `-n`

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- Add dry-run capability to print out the commit message we would have used.
<!-- SQUASH_MERGE_END -->


## Testing

Where you might be using this (e.g. `https://github.com/quotidian-ennui/ubuntu-dpm/pull/193`) do a `gh squash-merge --dry-run` and you should see something like

```shell
Ubuntu-22.04 phooey .../ubuntu-dpm feat/add-sonar-scanner
bsh ❯ gh squash-merge --dry-run
feat(sdk): add sonar-scanner cli

- add new target: just sdk sonar
- update test to github workflow to install sonar-scanner
- add new entry config/sdk.yml and corresponding updatecli config

Ubuntu-22.04 phooey .../ubuntu-dpm feat/add-sonar-scanner
bsh ❯
```

