### PR TITLE
refactor: use sed + tr to remove blank lines

### DIFF
--- a/gh-squash-merge
+++ b/gh-squash-merge
@@ -116,16 +116,19 @@ pr_view=$(gh pr view --json "number,body" $"${details_args[@]}")
 body=$(jq -r '.body' <<<"$pr_view")
 number=$(jq -r '.number' <<<"$pr_view")
 
-echo "$body" | awk '/SQUASH_MERGE_START/,/SQUASH_MERGE_END/' | { grep -v "SQUASH_MERGE" || test $? = 1; } >"$WORK_FILE"
+commit_msg=$(echo "$body" | awk '/SQUASH_MERGE_START/,/SQUASH_MERGE_END/' | { grep -v "SQUASH_MERGE" || test $? = 1; } | tr -d '\r' | sed '/^$/N;/^\n$/D')
+printf '%s\n' "$commit_msg" >"$WORK_FILE"
 
 if [[ "$DRY_RUN" == "true" ]]; then
   title=$(gh pr view --json title $"${details_args[@]}" --jq '.title')
+  echo ---
   echo -e "$title (#$number)\n"
   if [[ -s "$WORK_FILE" ]]; then
     cat "$WORK_FILE"
   else
     echo -e "⚠️ no squash-merge body in the PR"
   fi
+  echo ---
 else
   if [[ -s "$WORK_FILE" ]]; then
     gh pr merge $"${details_args[@]}" --delete-branch --squash --body-file "$WORK_FILE" $"${additional_args[@]}"


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Resolves #119

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- refactor: use sed + tr to remove blank lines
- wrap the dry-run msg with dashes



Ref: #119



<!-- SQUASH_MERGE_END -->

## Testing
<!-- Testing Notes -->

- `gh squash-merge --dry-run` on this PR should in fact do the right thing.
  - there are multiple blank lines between the trailer + body
  - there are multiple blank lines after the trailer
